### PR TITLE
[Pull Request] Auto labler for closed PR.

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -1,0 +1,22 @@
+name: "Pull Request Labeler"
+on:
+    pull_request:
+        types:
+            - closed
+
+jobs:
+    pr-merged:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: actions/github-script@v6
+              with:
+                  script: |
+                      github.rest.issues.addLabels({
+                        issue_number: context.issue.number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        labels: ["merged"]
+                      })


### PR DESCRIPTION
## What does this PR do?

Added GitHub Actions workflow config file to auto label closed PR with `merged` label.

<!-- Briefly describe what this PR is about -->

## Related issues

<!-- Link related issues below. -->
